### PR TITLE
Format Schema json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,42 @@ OpenMessaging is vendor-neutral and language-independent, provides industry guid
 Please see http://openmessaging.cloud/.
 
 # Schema
-    {       
+```json
+{
     "messages": {
-            "credential":{
-                "type": "user", 
-                "accountId": "123456789012", 
-                "accessKeyId": "EXAMPLE_KEY_ID", 
-                "userName": "Alice"
-                   },
-             "message":{
-                  "headers":{"userHeaders":{},"sysHeaders":{}},
-                  "properties"：{"messageId":"","bornTime":"","bornHost":"","storeTime":"","messageId":"","borenTime":"","bornHost":"","storeTime":"","deliveryTime":"","deliveryCount":"","ttl":"","correlationId":"","priority":"","traceId":"","transactionId":""},"bodies":{}
-                      }
-           }
+        "credential": {
+            "type": "user",
+            "accountId": "123456789012",
+            "accessKeyId": "EXAMPLE_KEY_ID",
+            "userName": "Alice"
+        },
+        "message": {
+            "headers": {
+                "userHeaders": {},
+                "sysHeaders": {}
+            },
+            "properties": {
+                "messageId": "",
+                "bornTime": "",
+                "bornHost": "",
+                "storeTime": "",
+                "messageId": "",
+                "borenTime": "",
+                "bornHost": "",
+                "storeTime": "",
+                "deliveryTime": "",
+                "deliveryCount": "",
+                "ttl": "",
+                "correlationId": "",
+                "priority": "",
+                "traceId": "",
+                "transactionId": ""
+            },
+            "bodies": {}
+        }
     }
+}
+```
 
 
 


### PR DESCRIPTION
## Motivation
Original scheme section is raw text and unformatted when the README page is displayed in the browser it has following issues:
1. it's too wide to read the schema without continuing scrolling the text box to right
2.all ` properties` are types in whole one line, it's hard to find the concerned

## Changes
1. change raw text to code block
2. fomart the schema json which makes it easy to read

