### PR TITLE
[ Minor Change ] Instead of {}, use [] as the value of payload in the example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please see http://openmessaging.cloud/.
             "properties": {
                "service": "helloService"
             },
-            "payload": {}
+            "payload": []
         }
     }
 ```

--- a/specification-schema.md
+++ b/specification-schema.md
@@ -301,7 +301,7 @@ In OpenMessaging, RPC is equal to synchronous message, it isn’t traditional CS
             "properties": {
                "service": "helloService"
             },
-            "payload": {}
+            "payload": []
         }
     }
 ```


### PR DESCRIPTION
As payload is binary, maybe it's  better use array ( '[]' in json ) in the example. 